### PR TITLE
#3 - Implemented 'context' passing between calls.

### DIFF
--- a/boson-core/src/main/java/boson/Utils.java
+++ b/boson-core/src/main/java/boson/Utils.java
@@ -1,5 +1,7 @@
 package boson;
 
+import boson.services.ServiceContextProvider;
+import boson.services.Services;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -207,5 +209,31 @@ public class Utils
     public static boolean hasValue(String text)
     {
         return (text != null) && text.trim().length() > 0;
+    }
+
+    /**
+     * Null-safe helper that returns the current context. This will return 'null' if there is no context provider for
+     * the given service repository.
+     * @param services The service repository where we'll pull the context provider from
+     * @param <T> The type describing the context
+     * @return The current security/authorization context (may be null)
+     */
+    public static <T> T getContext(Services services)
+    {
+        ServiceContextProvider<T> provider = services.getContextProvider();
+        return (provider == null) ? null : provider.getContext();
+    }
+
+    /**
+     * Null-safe helper that updates the current context within the given service repository. If you've set the context
+     * provider to null, this is effectively a noop.
+     * @param services The service repository whose context provider we'll use to apply the given context
+     * @param <T> The type describing the context
+     */
+    public static <T> void setContext(Services services, T context)
+    {
+        ServiceContextProvider<T> provider = services.getContextProvider();
+        if (provider != null)
+            provider.setContext(context);
     }
 }

--- a/boson-core/src/main/java/boson/services/ServiceContextProvider.java
+++ b/boson-core/src/main/java/boson/services/ServiceContextProvider.java
@@ -1,0 +1,25 @@
+package boson.services;
+
+/**
+ * An adapter for attaching a service context to a call or series of boson-activated calls. Different applications require
+ * different implementations to store a context for the duration of its usage. For instance, in a standard servlet app
+ * where threads are maintained for the duration of the request, you can use the reference ThreadLocalServiceContextProvider
+ * implementation to store your context for the life of the request. In a Play Framework application you can implement
+ * your own provider that interacts with their <code>Http.Context</code> structure to carry your context even as
+ * Play/Akka bounces the request from thread to thread.
+ *
+ * An implementation likely matches the threading/context model of the framework you're using to build your application.
+ */
+public interface ServiceContextProvider<T>
+{
+    /**
+     * @return The current context for the request or series of service calls
+     */
+    T getContext();
+
+    /**
+     * Applies the context to automatically pass along to remote service calls
+     * @param context The context to carry along
+     */
+    void setContext(T context);
+}

--- a/boson-core/src/main/java/boson/services/ServiceRequest.java
+++ b/boson-core/src/main/java/boson/services/ServiceRequest.java
@@ -21,6 +21,7 @@ public class ServiceRequest implements Serializable
     private Object[] arguments;
     private String correlation;
     private Instant expires;
+    private Object context;
 
     public ServiceRequest()
     {
@@ -139,6 +140,17 @@ public class ServiceRequest implements Serializable
     }
 
     /**
+     * @return The authorization/security context to send along to the remote call
+     */
+    public Object getContext() { return context; }
+
+    /**
+     * Sets the context that should be applied to the remote call
+     * @param context The context to send
+     */
+    public void setContext(Object context) { this.context = context; }
+
+    /**
      * Chaining support. Sets the correlation id/address for this request.
      * @param id The new value to apply
      * @return this
@@ -182,6 +194,17 @@ public class ServiceRequest implements Serializable
     public ServiceRequest args(Object[] arguments)
     {
         setArguments(arguments);
+        return this;
+    }
+
+    /**
+     * Chaining support. Applies the given security/authorization context to the request to be restored by the remote method.
+     * @param context The context to send and apply
+     * @return this
+     */
+    public ServiceRequest context(Object context)
+    {
+        setContext(context);
         return this;
     }
 

--- a/boson-core/src/main/java/boson/services/ThreadLocalServiceContextProvider.java
+++ b/boson-core/src/main/java/boson/services/ThreadLocalServiceContextProvider.java
@@ -1,0 +1,31 @@
+package boson.services;
+
+/**
+ * The reference implementation of security context providers which stores your context information on the current
+ * thread. Note that your application should properly wipe out the context at the disposal of your thread (or before
+ * it goes back into its pool).
+ */
+public class ThreadLocalServiceContextProvider<T> implements ServiceContextProvider<T>
+{
+    // Since this is theoretically a singleton in your app, non-static is OK so we use 'T' here
+    private final ThreadLocal<T> CONTEXTS = new ThreadLocal<>();
+
+    /**
+     * @return The current context for the request or series of service calls
+     */
+    @Override
+    public T getContext()
+    {
+        return CONTEXTS.get();
+    }
+
+    /**
+     * Applies the context to automatically pass along to remote service calls
+     * @param context The context to carry along
+     */
+    @Override
+    public void setContext(T context)
+    {
+        CONTEXTS.set(context);
+    }
+}

--- a/boson-core/src/main/java/boson/transport/ServiceBusDispatcher.java
+++ b/boson-core/src/main/java/boson/transport/ServiceBusDispatcher.java
@@ -2,6 +2,7 @@ package boson.transport;
 
 import boson.services.ServiceRequest;
 import boson.services.ServiceResponse;
+import boson.services.Services;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -25,6 +26,11 @@ public interface ServiceBusDispatcher<T> extends Function<ServiceRequest, Comple
     ServiceBusConfig getConfig();
 
     /**
+     * @return The repository/manager that this service is a member of
+     */
+    Services getServices();
+
+    /**
      * Performs any connection setup and resource allocation required to open a line of communication using this
      * transport mechanism. For instance in a message queue-based transport this may involve setting up a response
      * queue and discovering the request queue.
@@ -38,6 +44,13 @@ public interface ServiceBusDispatcher<T> extends Function<ServiceRequest, Comple
      * @return A future that completes w/ this dispatcher once all resources have been released
      */
     CompletableFuture<ServiceBusDispatcher<T>> disconnect();
+
+    /**
+     * Chaining support. A back-pointer to the service manager that holds the service registration for this dispatcher.
+     * @param services The service manager/repository this service is a member of
+     * @return this
+     */
+    ServiceBusDispatcher<T> in(Services services);
 
     /**
      * Chaining support.  A given producer is responsible for dispatching requests for just one type of service. This

--- a/boson-core/src/main/java/boson/transport/ServiceBusDispatcherAdapter.java
+++ b/boson-core/src/main/java/boson/transport/ServiceBusDispatcherAdapter.java
@@ -1,10 +1,13 @@
 package boson.transport;
 
+import boson.services.Services;
+
 /**
  * Manages the common book-keeping tasks required by most producer implementations.
  */
 public abstract class ServiceBusDispatcherAdapter<T> implements ServiceBusDispatcher<T>
 {
+    protected Services services;
     protected Class<T> serviceContract;
     protected boolean connected;
     protected ServiceBusConfig config;
@@ -21,6 +24,12 @@ public abstract class ServiceBusDispatcherAdapter<T> implements ServiceBusDispat
      */
     @Override
     public ServiceBusConfig getConfig() { return config; }
+
+    /**
+     * @return The repository/manager that this service is a member of
+     */
+    @Override
+    public Services getServices() { return services; }
 
     /**
      * Chaining support.  A given producer is responsible for dispatching requests for just one type of service. This
@@ -46,6 +55,18 @@ public abstract class ServiceBusDispatcherAdapter<T> implements ServiceBusDispat
     public ServiceBusDispatcher<T> config(ServiceBusConfig config)
     {
         this.config = config;
+        return this;
+    }
+
+    /**
+     * Chaining support. A back-pointer to the service manager that holds the service registration for this dispatcher.
+     * @param services The service manager/repository this service is a member of
+     * @return this
+     */
+    @Override
+    public ServiceBusDispatcher<T> in(Services services)
+    {
+        this.services = services;
         return this;
     }
 

--- a/boson-core/src/main/java/boson/transport/ServiceBusReceiver.java
+++ b/boson-core/src/main/java/boson/transport/ServiceBusReceiver.java
@@ -2,6 +2,7 @@ package boson.transport;
 
 import boson.services.ServiceRequest;
 import boson.services.ServiceResponse;
+import boson.services.Services;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -37,6 +38,11 @@ public interface ServiceBusReceiver<T> extends Function<ServiceRequest, Completa
     ServiceBusConfig getConfig();
 
     /**
+     * @return The repository/manager that this service is a member of
+     */
+    Services getServices();
+
+    /**
      * Fires up the service transport's communication channel so that it can start to receive requests and feed them
      * to the given service.
      * @param service The actual service instance that we're going to intercept work for
@@ -51,6 +57,12 @@ public interface ServiceBusReceiver<T> extends Function<ServiceRequest, Completa
      */
     CompletableFuture<ServiceBusReceiver<T>> disconnect();
 
+    /**
+     * Chaining support. A back-pointer to the service manager that holds the service registration for this receiver.
+     * @param services The service manager/repository this service is a member of
+     * @return this
+     */
+    ServiceBusReceiver<T> in(Services services);
 
     /**
      * Chaining support. Your service may implement any number of interfaces. This tells us which of those interfaces defines the

--- a/boson-examples/src/main/java/boson/examples/context/HelloContext.java
+++ b/boson-examples/src/main/java/boson/examples/context/HelloContext.java
@@ -1,0 +1,72 @@
+package boson.examples.context;
+
+import boson.Futures;
+import boson.Utils;
+import boson.examples.services.HelloService;
+import boson.services.Services;
+import boson.transport.ServiceBusConfig;
+import boson.transport.http.HttpTransportBindings;
+import org.slf4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This is a slight variant of the standard HelloHttp client/consumer code that still performs a handful of operations
+ * using the HTTP transport, but also passes some user context information across to the service so your identity is
+ * carried along to all other operations.
+ */
+public class HelloContext
+{
+    private static Logger logger = Utils.logger(HelloContext.class);
+
+    public static void main(String [] args) throws Exception
+    {
+        logger.info("ContextPassing Starting");
+
+        // By default Boson applies a 'ThreadLocal' provider so add our context to the current thread, but you can
+        // swap your custom implementation in here as needed. This, however, is sufficient for servlet-based apps.
+        Services services = new Services();
+        HelloService service = Futures.await(services.consume(
+            HelloService.class,
+            new HttpTransportBindings<>(),
+            new ServiceBusConfig().uri("http://localhost:5454")));
+
+        // Execute a series of service calls as one user in Thread A
+        CompletableFuture<Void> bob = CompletableFuture.runAsync(() -> {
+            services.getContextProvider().setContext(createContext("12345", "Bob", "bob@example.com"));
+            Futures.awaitAll(
+                service.say("Hello World").thenAccept(logger::info),
+                service.say("Doc says hello").thenAccept(logger::info));
+        });
+
+        // Execute a series of service calls as a completely separate user in Thread B
+        CompletableFuture<Void> jane = CompletableFuture.runAsync(() -> {
+            services.getContextProvider().setContext(createContext("ABCDE", "Jane", "jane@example.com"));
+            Futures.awaitAll(
+                service.say("Hello World").thenAccept(logger::info),
+                service.say("Doc says hello").thenAccept(logger::info));
+        });
+
+        // Make sure that both Bob and Jane's tasks have completed
+        Futures.awaitAll(bob, jane);
+        logger.info("All tasks completed. Shutting down service connections.");
+        Futures.await(services.disconnectAll());
+    }
+
+    /**
+     * Create a dummy object that can be passed to the remote service implementation to represent the user making the
+     * given request. In reality this would be something like a Spring SecurityContext or a JSON Web Token or whatever
+     * represents your temporary "state" information.
+     * @return The map of user details
+     */
+    protected static Map<String, String> createContext(String id, String name, String email)
+    {
+        Map<String, String> context = new HashMap<>();
+        context.put("id", id);
+        context.put("name", name);
+        context.put("email", email);
+        return context;
+    }
+}

--- a/boson-examples/src/main/java/boson/examples/context/HelloContextServices.java
+++ b/boson-examples/src/main/java/boson/examples/context/HelloContextServices.java
@@ -1,0 +1,37 @@
+package boson.examples.context;
+
+import boson.Futures;
+import boson.Utils;
+import boson.examples.services.ContextAwareHelloService;
+import boson.examples.services.HelloService;
+import boson.services.Services;
+import boson.transport.ServiceBusConfig;
+import boson.transport.http.HttpTransportBindings;
+import org.slf4j.Logger;
+
+/**
+ * Uses the HTTP transport to fire up a Boson-activated HelloService that is capable of receiving/logging user context
+ * info that's automatically passed along with each request to the services we register here.
+ */
+public class HelloContextServices
+{
+    private static Logger logger = Utils.logger(HelloContextServices.class);
+
+    public static void main(String [] args) throws Exception
+    {
+        logger.info("Starting HelloContextServices");
+        Services services = new Services();
+
+        // Other than having a reference to 'services' passed to our service this is the exact same setup as HelloHttpServices.
+        // See the comments at the top of ContextAwareHelloService.java for a better way to do this.
+        Futures.await(services.implement(
+            HelloService.class,
+            new ContextAwareHelloService(services),
+            new HttpTransportBindings<>(),
+            new ServiceBusConfig().uri("http://localhost:5454")));
+
+        logger.info("HelloContextServices up and running. Press ENTER to quit.");
+        System.console().readLine();
+        Futures.await(services.disconnectAll());
+    }
+}

--- a/boson-examples/src/main/java/boson/examples/services/ContextAwareHelloService.java
+++ b/boson-examples/src/main/java/boson/examples/services/ContextAwareHelloService.java
@@ -1,0 +1,56 @@
+package boson.examples.services;
+
+import boson.Utils;
+import boson.services.Services;
+import org.slf4j.Logger;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An implementation of the HelloService that is aware of user principal/context information sent along by callers. For
+ * this example we brute-force access to the context info but in a serious production application you'd probably want
+ * to bury access to the 'Services' object in your own abstraction so you can better decouple your Boson code from your
+ * service code.
+ */
+public class ContextAwareHelloService extends SimpleHelloService
+{
+    private static Logger logger = Utils.logger(ContextAwareHelloService.class);
+
+    /** Provides access to the context provider */
+    private Services services;
+
+    /**
+     * Creates the service instance, aware of the repository it belongs to so that it can pull context info
+     * @param services The service repository this service belongs to and contains the context provider.
+     */
+    public ContextAwareHelloService(Services services)
+    {
+        this.services = services;
+    }
+
+    /**
+     * Given a string like "Hello X", return the text "Goodbye X"
+     * @param phrase The incoming hello phrase to parse and respond to
+     * @return The "hello" phrase where "Hello" is replaced w/ "Goodbye"
+     */
+    @Override
+    public CompletableFuture<String> say(String phrase)
+    {
+        // This would get ridiculous in a real application so look at Google Guice AOP for info on how to create a
+        // logging aspect that puts your method logging in 1 place: https://github.com/google/guice/wiki/AOP
+        Map<String, String> context = Utils.getContext(services);
+        if (context != null)
+        {
+            logger.info(String.format("Invoking HelloService.say() as [id=%s][name=%s][email=%s]",
+                context.get("id"),
+                context.get("name"),
+                context.get("email")));
+        }
+        else
+        {
+            logger.info("Invoking HelloService.say() as 'anonymous'");
+        }
+        return super.say(phrase);
+    }
+}


### PR DESCRIPTION
I've added a ```ServiceContextProvider``` class which allows you to create a "context" out of any old object (because I don't want to endorse one specific framework's model). This context object is automatically included as part of the ```ServiceRequest``` and is restored by the underlying service receiver. Additionally, the on the consumer/proxy side, the context is restored after the response comes back to allow for any thread-stealing or actor framework wankery so we can continue the client-side operation just as we left it.