### PR TITLE
#7 - Extracted serialization into pluggable component.

### DIFF
--- a/.idea/artifacts/boson_examples_jar.xml
+++ b/.idea/artifacts/boson_examples_jar.xml
@@ -14,6 +14,9 @@
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/eclipse/jetty/jetty-util/9.3.9.v20160517/jetty-util-9.3.9.v20160517.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/eclipse/jetty/jetty-io/9.3.9.v20160517/jetty-io-9.3.9.v20160517.jar" path-in-jar="/" />
       <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/slf4j/slf4j-simple/1.7.21/slf4j-simple-1.7.21.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/de/ruedigermoeller/fst/2.47/fst-2.47.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/org/objenesis/objenesis/2.4/objenesis-2.4.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$MAVEN_REPOSITORY$/com/fasterxml/jackson/core/jackson-core/2.5.3/jackson-core-2.5.3.jar" path-in-jar="/" />
     </root>
   </artifact>
 </component>

--- a/boson-core/boson-core.iml
+++ b/boson-core/boson-core.iml
@@ -15,5 +15,9 @@
     <orderEntry type="library" scope="TEST" name="junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" name="Maven: de.ruedigermoeller:fst:2.47" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.5.3" level="project" />
+    <orderEntry type="library" name="Maven: org.javassist:javassist:3.19.0-GA" level="project" />
+    <orderEntry type="library" name="Maven: org.objenesis:objenesis:2.4" level="project" />
   </component>
 </module>

--- a/boson-core/pom.xml
+++ b/boson-core/pom.xml
@@ -10,12 +10,19 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>boson-core</artifactId>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.ruedigermoeller</groupId>
+            <artifactId>fst</artifactId>
+            <version>2.47</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/boson-core/src/main/java/boson/Utils.java
+++ b/boson-core/src/main/java/boson/Utils.java
@@ -93,33 +93,6 @@ public class Utils
     }
 
     /**
-     * Reconstitutes an instance of T from the serialized bytes provided. This is a dumb implementation that fully trusts
-     * that the bytes (A) represent a serialized object and (B) that when put back together is really an instance of T,
-     * so it's possible to get a ClassCastException if you're being stupid/careless.
-     * @param serializedBytes The raw bytes of the serialized instance (output of the <code>Utils.serialize()</code> method)
-     * @return The original POJO, now reconstituted from the bytes
-     * @throws ClassNotFoundException If the deserialized object is not in this class loader's classpath.
-     * @throws IOException If anything else goes wrong during the deserialization process
-     * @throws ClassCastException If you were dumb and the resulting object wasn't actually an instance of type T.
-     */
-    @SuppressWarnings("unchecked")
-    public static <T> T deserialize(InputStream serializedBytes) throws ClassNotFoundException, IOException
-    {
-        if (serializedBytes != null)
-        {
-            try (ObjectInputStream in = new ObjectInputStream(serializedBytes))
-            {
-                return (T)in.readObject();
-            }
-            finally
-            {
-                close(serializedBytes);
-            }
-        }
-        return null;
-    }
-
-    /**
      * Quietly close the given resource. It doesn't matter if the resource is null, already closed, or just barfs in
      * the process - this will give it the old college try.
      * @param closeable The resource you want to close/dispose.

--- a/boson-core/src/main/java/boson/transport/serialize/FSTSerializationEngine.java
+++ b/boson-core/src/main/java/boson/transport/serialize/FSTSerializationEngine.java
@@ -1,0 +1,88 @@
+package boson.transport.serialize;
+
+import boson.Utils;
+import boson.services.ServiceRequest;
+import boson.services.ServiceResponse;
+import org.nustaq.serialization.FSTConfiguration;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+
+/**
+ * Describes a component that is capable of taking some Serializable object and turning into the raw bytes that we'll
+ * send through the transport.
+ */
+public class FSTSerializationEngine implements SerializationEngine
+{
+    private static FSTConfiguration FST = FSTConfiguration.createDefaultConfiguration();
+    static
+    {
+        // Optimization described in https://github.com/RuedigerMoeller/fast-serialization/wiki/Serialization to avoid
+        // serializing the fully-qualified class name for our most-frequently serialized objects. As these two classes
+        // literally encapsulate EVERYTHING we serialize, this cuts down on the size/time of every serialization.
+        FST.registerClass(ServiceRequest.class, ServiceResponse.class);
+    }
+
+    /**
+     * Convert the given object into serialized bytes
+     * @param obj The POJO to convert into raw bytes
+     * @return The resulting bytes
+     */
+    @Override
+    public byte[] objectToBytes(Serializable obj) throws IOException
+    {
+        return (obj != null)
+            ? FST.asByteArray(obj)
+            : new byte[0];
+    }
+
+    /**
+     * Reverses the serialization process, taking the serialized bytes and turning it back into the original POJO
+     * @param type The type of the resulting deserialized object
+     * @param bytes The serialized bytes
+     * @return The original POJO
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T bytesToObject(Class<T> type, byte[] bytes) throws IOException, ClassNotFoundException
+    {
+        return (bytes != null && bytes.length > 0)
+            ? (T)FST.asObject(bytes)
+            : null;
+    }
+
+    /**
+     * Reverses the serialization process, taking the serialized bytes and turning it back into the original POJO
+     * @param type The type of the resulting deserialized object
+     * @param bytes The serialized bytes
+     * @return The original POJO
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T streamToObject(Class<T> type, InputStream bytes) throws IOException, ClassNotFoundException
+    {
+        if (bytes != null)
+        {
+            try
+            {
+                // DO NOT close the FSTObjectInput object. We can close the byte input stream, but FST re-uses its
+                // object input stream instances in a thread-safe way so just do as the docs say and leave it open.
+                return (T)FST.getObjectInput(bytes).readObject(type);
+            }
+            catch (RuntimeException | IOException | ClassNotFoundException e)
+            {
+                throw e;
+            }
+            catch (Exception e)  // for some reason 'readObject()'
+            {
+                throw new IOException(e);
+            }
+            finally
+            {
+                Utils.close(bytes);
+            }
+        }
+        return null;
+    }
+}

--- a/boson-core/src/main/java/boson/transport/serialize/JavaSerializationEngine.java
+++ b/boson-core/src/main/java/boson/transport/serialize/JavaSerializationEngine.java
@@ -16,7 +16,7 @@ public class JavaSerializationEngine implements SerializationEngine
      * @return The resulting bytes
      */
     @Override
-    public byte[] toBytes(Serializable obj) throws IOException
+    public byte[] objectToBytes(Serializable obj) throws IOException
     {
         if (obj != null)
         {
@@ -32,12 +32,13 @@ public class JavaSerializationEngine implements SerializationEngine
 
     /**
      * Reverses the serialization process, taking the serialized bytes and turning it back into the original POJO
+     * @param type The type of the resulting deserialized object
      * @param bytes The serialized bytes
      * @return The original POJO
      */
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T fromBytes(byte[] bytes) throws IOException, ClassNotFoundException
+    public <T> T bytesToObject(Class<T> type, byte[] bytes) throws IOException, ClassNotFoundException
     {
         if (bytes != null && bytes.length > 0)
         {
@@ -52,12 +53,13 @@ public class JavaSerializationEngine implements SerializationEngine
 
     /**
      * Reverses the serialization process, taking the serialized bytes and turning it back into the original POJO
+     * @param type The type of the resulting deserialized object
      * @param bytes The serialized bytes
      * @return The original POJO
      */
     @Override
     @SuppressWarnings("unchecked")
-    public <T> T fromBytes(InputStream bytes) throws IOException, ClassNotFoundException
+    public <T> T streamToObject(Class<T> type, InputStream bytes) throws IOException, ClassNotFoundException
     {
         if (bytes != null)
         {

--- a/boson-http/src/main/java/boson/transport/http/HttpServiceBusDispatcher.java
+++ b/boson-http/src/main/java/boson/transport/http/HttpServiceBusDispatcher.java
@@ -75,7 +75,7 @@ class HttpServiceBusDispatcher<T> extends ServiceBusDispatcherAdapter<T> impleme
             // The body of the POST is just the serialized bytes of the ServiceRequest instance
             connection.setDoOutput(true);
             OutputStream postData = connection.getOutputStream();
-            postData.write(config.getSerializationEngine().toBytes(request));
+            postData.write(config.getSerializationEngine().objectToBytes(request));
             postData.flush();
             postData.close();
 
@@ -83,7 +83,8 @@ class HttpServiceBusDispatcher<T> extends ServiceBusDispatcherAdapter<T> impleme
             int responseCode = connection.getResponseCode();
             if (responseCode >= 200 && responseCode <= 299)
             {
-                future.complete(Utils.deserialize(connection.getInputStream()));
+                future.complete(config.getSerializationEngine()
+                    .streamToObject(ServiceResponse.class, connection.getInputStream()));
             }
             else
             {

--- a/boson-rabbitmq/src/main/java/boson/transport/rabbitmq/RabbitMQServiceBusDispatcher.java
+++ b/boson-rabbitmq/src/main/java/boson/transport/rabbitmq/RabbitMQServiceBusDispatcher.java
@@ -60,7 +60,7 @@ class RabbitMQServiceBusDispatcher<T> extends ServiceBusDispatcherAdapter<T>
                 .build();
 
             // Request queue name is the fully qualified service contract interface, not just the simple name
-            byte[] requestBytes = config.getSerializationEngine().toBytes(request);
+            byte[] requestBytes = config.getSerializationEngine().objectToBytes(request);
             queueClient.getChannel().basicPublish("", getServiceContract().getName(), properties, requestBytes);
             return response;
         }
@@ -129,7 +129,8 @@ class RabbitMQServiceBusDispatcher<T> extends ServiceBusDispatcherAdapter<T>
                 if (logger.isTraceEnabled())
                     logger.trace("[{}] Response received, routing to correct future.", getServiceName());
 
-                responseRouter.completeRoute(config.getSerializationEngine().fromBytes(responseBytes));
+                responseRouter.completeRoute(config.getSerializationEngine()
+                    .bytesToObject(ServiceResponse.class, responseBytes));
             }
             catch (InterruptedException | ShutdownSignalException e)
             {

--- a/boson-rabbitmq/src/main/java/boson/transport/rabbitmq/RabbitMQServiceBusReceiver.java
+++ b/boson-rabbitmq/src/main/java/boson/transport/rabbitmq/RabbitMQServiceBusReceiver.java
@@ -109,7 +109,7 @@ class RabbitMQServiceBusReceiver<T> extends ServiceBusReceiverAdapter<T>
 
             // The RabbitMQ client doesn't support stream-based bodies, so we need to realize the entire byte array.
             byte [] messageBody = queueClient.getQueueConsumer().nextDelivery().getBody();
-            return config.getSerializationEngine().fromBytes(messageBody);
+            return config.getSerializationEngine().bytesToObject(ServiceRequest.class, messageBody);
         }
         catch (ShutdownSignalException e)
         {
@@ -163,7 +163,7 @@ class RabbitMQServiceBusReceiver<T> extends ServiceBusReceiverAdapter<T>
                 .build();
 
             // The RabbitMQ client doesn't support streams so it has to be a fully realized by array
-            byte[] responseBytes = config.getSerializationEngine().toBytes(response);
+            byte[] responseBytes = config.getSerializationEngine().objectToBytes(response);
             queueClient.getChannel().basicPublish("", response.getCorrelation(), properties, responseBytes);
         }
         catch (Throwable t)


### PR DESCRIPTION
Redefined the API for ```SerializationEngine``` to be more robust and implemented ```FSTSerializationEngine``` as a baked-in alternative to standard Java serialization.